### PR TITLE
Files hashed for login updated.  DX9 mode removed.

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -18,12 +18,7 @@ else:
 	from ConfigParser import ConfigParser
 
 def gen_launcher_command(settings):
-	exe_path=settings['path']
-
-	if(settings['use_dx11'].strip() == 'True'):
-		exe_path = join_path(exe_path,'game/ffxiv_dx11.exe')
-	else:
-		exe_path = join_path(exe_path,'game/ffxiv.exe')
+	exe_path=settings['path'] + '/game/ffxiv_dx11.exe'
 
 	launcher_dict = [
 		exe_path,

--- a/launcher_config.ini
+++ b/launcher_config.ini
@@ -9,16 +9,16 @@ USEGUI = True
 # 2 = Stormblood
 # 3 = Shadowbringers
 # 4 = Endwalker
+# 5 = Dawntrail
 expansion_id = 4
 # Region you play the game in (3 is US)
 region = 3
-#Use Direct X 11 mode
-use_dx11 = True
-#Absolute path to the game's directory (DON'T use quotes)
-path =
-#Command to run before executing the game
-#Leave blank for windows or MacOS, 'wine' for Linux
-pre_command =
-user =
-password =
-one_time_password =
+# Absolute path to the game's directory (DON'T use quotes)
+path = 
+# Command to run before executing the game
+# Leave blank for windows or MacOS, 'wine' for Linux
+pre_command = 
+# Pre-fill if preferable.
+user = 
+password = 
+one_time_password = 

--- a/login.py
+++ b/login.py
@@ -98,9 +98,7 @@ def get_actual_sid(sid,gamepath):
 
     version_hash = gen_hash(join_path(gamepath,"boot/ffxivboot.exe"))+"," \
               +gen_hash(join_path(gamepath,"boot/ffxivboot64.exe"))+"," \
-              +gen_hash(join_path(gamepath,"boot/ffxivlauncher.exe"))+"," \
               +gen_hash(join_path(gamepath,"boot/ffxivlauncher64.exe"))+"," \
-              +gen_hash(join_path(gamepath,"boot/ffxivupdater.exe"))+"," \
               +gen_hash(join_path(gamepath,"boot/ffxivupdater64.exe"))
 
     #Note:  This will fail with a 401 error for someone with an expired subscription


### PR DESCRIPTION
DX9 mode removed by Square.  Respective hash files for it no longer exist.

Linux handles the `+ '/game/ffxiv_dx11.exe'` line fine whether the game directory's configured with a trailing `/` or not.  I don't know if Windows handles that gracefully or not.